### PR TITLE
[FIX] stock-logistics-warehouse: openupgradelib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/OCA/openupgradelib.git@master#egg=openupgradelib
+openupgradelib @ git+https://github.com/OCA/openupgradelib.git


### PR DESCRIPTION
Openupgradelib has conflicting dependencies between [server-ux](https://github.com/Vauxoo/server-ux/blob/12.0/requirements.txt#L3) and [stock-logistics-warehouse](https://github.com/Vauxoo/stock-logistics-warehouse/blob/12.0/requirements.txt#L1)

ERROR: 

```
Cannot install openupgradelib 3.0.0 (from git+https://github.com/OCA/openupgradelib.git) and openupgradelib 3.0.0 (from git+https://github.com/OCA/openupgradelib.git@master#egg=openupgradelib) because these package versions have conflicting dependencies.

The conflict is caused by:

The user requested openupgradelib 3.0.0 (from git+https://github.com/OCA/openupgradelib.git)

The user requested openupgradelib 3.0.0 (from git+https://github.com/OCA/openupgradelib.git@master#egg=openupgradelib)
```