### PR TITLE
[FIX] stock_mts_mto_rule: self-heal MTS+MTO route on load-order race

### DIFF
--- a/stock_mts_mto_rule/models/stock_warehouse.py
+++ b/stock_mts_mto_rule/models/stock_warehouse.py
@@ -38,6 +38,35 @@ class StockWarehouse(models.Model):
             return _("MTS+MTO")
         return super(StockWarehouse, self)._get_route_name(route_type)
 
+    def _get_mts_mto_route(self):
+        """Return the global "Make To Order + Make To Stock" route, creating
+        it (and binding its xml_id) if it doesn't exist yet.
+
+        ``_find_global_route`` (create=False) assumes this module's own
+        data/stock_data.xml has already run, but that isn't guaranteed:
+        stock_mts_mto_rule has no dependency relationship with modules like
+        purchase_stock, whose post_init_hook can trigger a warehouse route
+        rebuild before this module's data file has loaded, raising a
+        UserError instead of self-healing. _load_records uses the same
+        create-or-get-by-xml_id mechanism as loading the XML data file, so
+        if that file loads afterwards it will find the xml_id already bound
+        and update this record in place instead of duplicating it.
+        """
+        return self.env["stock.route"]._load_records(
+            [
+                {
+                    "xml_id": "stock_mts_mto_rule.route_mto_mts",
+                    "values": {
+                        "name": _("Make To Order + Make To Stock"),
+                        "sequence": 5,
+                        "product_selectable": True,
+                        "company_id": False,
+                    },
+                    "noupdate": True,
+                }
+            ]
+        )
+
     def _get_global_route_rules_values(self):
         rule = self.get_rules_dict()[self.id][self.delivery_steps]
         rule = [r for r in rule if r.from_loc == self.lot_stock_id][0]
@@ -55,10 +84,7 @@ class StockWarehouse(models.Model):
                         "company_id": self.company_id.id,
                         "auto": "manual",
                         "propagate_cancel": True,
-                        "route_id": self._find_global_route(
-                            "stock_mts_mto_rule.route_mto_mts",
-                            _("Make To Order + Make To Stock"),
-                        ).id,
+                        "route_id": self._get_mts_mto_route().id,
                     },
                     "update_values": {
                         "active": self.mto_mts_management,


### PR DESCRIPTION
What was the problem?

Installing `coinsamatik` from scratch (e.g. on a fresh Odoo.sh instance) crashes with:

    User Error: Can't find any generic route Make To Order + Make To Stock.

Root cause (confirmed with a full traceback from real logs): `purchase_stock` (Odoo core module) has a `post_init_hook` that, once it finishes loading, writes `buy_to_resupply=True` on warehouses. That write triggers a rebuild of all global warehouse routes, including the one defined by `stock_mts_mto_rule` ("Make To Order + Make To Stock"). The issue is that `stock_mts_mto_rule` looks up that route assuming it already exists (`create=False`) — but its own data file, the one that creates it, hadn't loaded yet at that point.

This happens because `stock_mts_mto_rule` and `purchase_stock` have no dependency relationship with each other — they're simply "cousins" in the tree (both only depend on `stock`). Odoo doesn't guarantee any ordering between modules that don't depend on one another; in this specific module tree pulled in by `coinsamatik`, `purchase_stock` always ends up loading first.

Why didn't we use dependencies to force the order?

We evaluated this thoroughly since it looked like the "obvious" fix, but it doesn't work for two reasons:

1. Reordering the `depends` list in the manifest does nothing. We verified directly in Odoo's source code (`odoo/modules/graph.py`) that module load order does NOT use the order in which the list is written — Odoo computes a real topological depth (1 + the max depth among its dependencies), and when two modules tie on depth, it sorts them alphabetically by name. Since "purchase_stock" sorts before "stock_mts_mto_rule" alphabetically, it always wins the race regardless of how we order the manifest.

2. Adding an explicit dependency backfires. If we made `stock_mts_mto_rule` depend on `purchase_stock`, that would force `purchase_stock` to load first (dependencies always load before their dependents) — exactly the precondition that causes the bug, now guaranteed instead of just probable. And we can't make `purchase_stock` (Odoo core) depend on a third-party OCA add-on without patching Odoo itself, which is out of scope and fragile across versions.

We also tried a manual workaround (installing `purchase_stock` alone first, then `coinsamatik`) — it avoided the original error, but exposed a second, related bug (a `ValidationError` on a FK constraint while rebuilding `stock.picking.type` during the second install). This confirmed that "controlling the order" is fragile and just trades one problem for another — not a real, repeatable fix for every new instance.

Why this approach, then?

Since the load order can't be reliably controlled, the correct fix is for `stock_mts_mto_rule` to stop depending on "who gets there first": instead of requiring the route to already exist, it now creates it on demand if not found, using `_load_records` — the same internal mechanism Odoo itself uses to load its own XML data, binding it to the same `xml_id` the module already uses. This way, no matter which module wins the race, the route is guaranteed to exist, and if the original data file loads afterwards, Odoo recognizes the `xml_id` is already bound and updates the existing record instead of duplicating it.


### Changes

_get_global_route_rules_values() looked up the "Make To Order + Make To Stock" route with create=False, assuming this module's own data/stock_data.xml had already created it. That isn't guaranteed: stock_mts_mto_rule has no dependency relationship with modules such as purchase_stock, whose post_init_hook can trigger a warehouse route rebuild before this module's data file has loaded (Odoo breaks the tie between same-depth modules alphabetically, and "purchase_stock" sorts before "stock_mts_mto_rule"), raising "Can't find any generic route Make To Order + Make To Stock." and aborting the install.

_get_mts_mto_route() now creates the route on demand via _load_records, binding it to the same xml_id the data file uses, so a later load of that file updates the existing record instead of duplicating it. This makes the route independent of module load order.

